### PR TITLE
Logic and tests added for SQS FIFO Queue Type

### DIFF
--- a/src/Queues/SqsMessageQueue.cs
+++ b/src/Queues/SqsMessageQueue.cs
@@ -267,6 +267,9 @@ namespace PipServices3.Aws.Queues
         {
             CheckOpened(correlationId);
 
+            // Set the message sent time
+            message.SentTime = DateTime.UtcNow;
+
             await _client.SendMessageAsync(CreateSendMessageRequest(message, _contentBasedDupication, _queue), _cancel.Token);
 
             _counters.IncrementOne("queue." + Name + ".sent_messages");

--- a/src/Queues/SqsMessageQueue.cs
+++ b/src/Queues/SqsMessageQueue.cs
@@ -438,14 +438,14 @@ namespace PipServices3.Aws.Queues
             {
                 while (true)
                 {
-                    var messages = await PeekBatchAsync(correlationId, 100);
+                    var messages = await PeekBatchAsync(correlationId, 10);
 
                     foreach (var message in messages)
                     {
                         await CompleteAsync(message);
                     }
 
-                    if (messages.Count < 90) break;
+                    if (messages.Count < 9) break;
                 }
             }
 

--- a/src/Queues/SqsMessageQueue.cs
+++ b/src/Queues/SqsMessageQueue.cs
@@ -247,7 +247,7 @@ namespace PipServices3.Aws.Queues
                 QueueUrl = _queue,
                 WaitTimeSeconds = 0,
                 VisibilityTimeout = 0,
-                MaxNumberOfMessages = 1
+                MaxNumberOfMessages = messageCount
             };
             var response = await _client.ReceiveMessageAsync(request, _cancel.Token);
 

--- a/src/Queues/SqsMessageQueueFactory.cs
+++ b/src/Queues/SqsMessageQueueFactory.cs
@@ -7,13 +7,13 @@ namespace PipServices3.Aws.Queues
     public class SqsMessageQueueFactory : Factory, IConfigurable
     {
         public static readonly Descriptor Descriptor = new Descriptor("pip-services3-aws", "factory", "message-queue", "sqs", "1.0");
-        public static readonly Descriptor MemoryQueueDescriptor = new Descriptor("pip-services3-aws", "message-queue", "sqs", "*", "*");
+        public static readonly Descriptor SqsMessageQueueDescriptor = new Descriptor("pip-services3-aws", "message-queue", "sqs", "*", "*");
 
         private ConfigParams _config;
 
         public SqsMessageQueueFactory()
         {
-            Register(MemoryQueueDescriptor, (locator) => {
+            Register(SqsMessageQueueDescriptor, (locator) => {
                 Descriptor descriptor = (Descriptor)locator;
                 var queue = new SqsMessageQueue(descriptor.Name);
                 if (_config != null)

--- a/test/Queues/MessageQueueFixture.cs
+++ b/test/Queues/MessageQueueFixture.cs
@@ -8,10 +8,12 @@ namespace PipServices3.Aws.Queues
     public class MessageQueueFixture
     {
         private IMessageQueue _queue;
+        private bool _isFifo;
 
-        public MessageQueueFixture(IMessageQueue queue)
+        public MessageQueueFixture(IMessageQueue queue, bool isFifo)
         {
             _queue = queue;
+            _isFifo = isFifo;
         }
 
         public async Task TestSendReceiveMessageAsync()
@@ -70,8 +72,8 @@ namespace PipServices3.Aws.Queues
             Assert.Equal(envelope1.CorrelationId, envelope2.CorrelationId);
 
             await _queue.CompleteAsync(envelope2);
-            //envelope2 = await _queue.PeekAsync();
-            //Assert.IsNull(envelope2);
+            envelope2 = await _queue.PeekAsync(null);
+            Assert.Null(envelope2);
         }
 
         public async Task TestReceiveAndAbandonMessageAsync()

--- a/test/Queues/MessageQueueFixture.cs
+++ b/test/Queues/MessageQueueFixture.cs
@@ -2,21 +2,24 @@
 using System.Threading.Tasks;
 using Xunit;
 using PipServices3.Messaging.Queues;
+using PipServices3.Commons.Data;
 
 namespace PipServices3.Aws.Queues
 {
     public class MessageQueueFixture
     {
         private IMessageQueue _queue;
+        private bool _isFifo;
 
-        public MessageQueueFixture(IMessageQueue queue)
+        public MessageQueueFixture(IMessageQueue queue, bool isFifo)
         {
             _queue = queue;
+            _isFifo = isFifo;
         }
 
         public async Task TestSendReceiveMessageAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
             await _queue.SendAsync(null, envelope1);
 
             var count = _queue.MessageCount;
@@ -27,11 +30,14 @@ namespace PipServices3.Aws.Queues
             Assert.Equal(envelope1.MessageType, envelope2.MessageType);
             Assert.Equal(envelope1.Message, envelope2.Message);
             Assert.Equal(envelope1.CorrelationId, envelope2.CorrelationId);
+
+            if (_isFifo)
+                await _queue.CompleteAsync(envelope2);
         }
 
         public async Task TestMoveToDeadMessageAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
             await _queue.SendAsync(null, envelope1);
 
             var envelope2 = await _queue.ReceiveAsync(null, 10000);
@@ -45,9 +51,10 @@ namespace PipServices3.Aws.Queues
 
         public async Task TestReceiveSendMessageAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
 
-            ThreadPool.QueueUserWorkItem(async delegate {
+            ThreadPool.QueueUserWorkItem(async delegate
+            {
                 Thread.Sleep(500);
                 await _queue.SendAsync(null, envelope1);
             });
@@ -57,11 +64,14 @@ namespace PipServices3.Aws.Queues
             Assert.Equal(envelope1.MessageType, envelope2.MessageType);
             Assert.Equal(envelope1.Message, envelope2.Message);
             Assert.Equal(envelope1.CorrelationId, envelope2.CorrelationId);
+
+            if (_isFifo)
+                await _queue.CompleteAsync(envelope2);
         }
 
         public async Task TestReceiveAndCompleteMessageAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
             await _queue.SendAsync(null, envelope1);
             var envelope2 = await _queue.ReceiveAsync(null, 10000);
             Assert.NotNull(envelope2);
@@ -70,13 +80,13 @@ namespace PipServices3.Aws.Queues
             Assert.Equal(envelope1.CorrelationId, envelope2.CorrelationId);
 
             await _queue.CompleteAsync(envelope2);
-            //envelope2 = await _queue.PeekAsync();
-            //Assert.IsNull(envelope2);
+            envelope2 = await _queue.PeekAsync(null);
+            Assert.Null(envelope2);
         }
 
         public async Task TestReceiveAndAbandonMessageAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
             await _queue.SendAsync(null, envelope1);
             var envelope2 = await _queue.ReceiveAsync(null, 10000);
             Assert.NotNull(envelope2);
@@ -90,18 +100,28 @@ namespace PipServices3.Aws.Queues
             Assert.Equal(envelope1.MessageType, envelope2.MessageType);
             Assert.Equal(envelope1.Message, envelope2.Message);
             Assert.Equal(envelope1.CorrelationId, envelope2.CorrelationId);
+
+            if (_isFifo)
+                await _queue.CompleteAsync(envelope2);
         }
 
         public async Task TestSendPeekMessageAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
             await _queue.SendAsync(null, envelope1);
             await Task.Delay(500);
+
             var envelope2 = await _queue.PeekAsync(null);
             Assert.NotNull(envelope2);
             Assert.Equal(envelope1.MessageType, envelope2.MessageType);
             Assert.Equal(envelope1.Message, envelope2.Message);
             Assert.Equal(envelope1.CorrelationId, envelope2.CorrelationId);
+
+            if (_isFifo)
+            {
+                envelope2 = await _queue.ReceiveAsync(null, 10000);
+                await _queue.CompleteAsync(envelope2);
+            }
         }
 
         public async Task TestPeekNoMessageAsync()
@@ -112,20 +132,28 @@ namespace PipServices3.Aws.Queues
 
         public async Task TestMessageCountAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
             await _queue.SendAsync(null, envelope1);
             await Task.Delay(500);
+
             var count = _queue.MessageCount;
             Assert.NotNull(count);
             Assert.True(count.Value >= 1);
+
+            if (_isFifo)
+            {
+                var envelope2 = await _queue.ReceiveAsync(null, 10000);
+                await _queue.CompleteAsync(envelope2);
+            }
         }
 
         public async Task TestOnMessageAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
             MessageEnvelope envelope2 = null;
 
-            _queue.BeginListen(null, async (envelope, queue) => {
+            _queue.BeginListen(null, async (envelope, queue) =>
+            {
                 envelope2 = envelope;
                 await Task.Delay(0);
             });
@@ -138,8 +166,10 @@ namespace PipServices3.Aws.Queues
             Assert.Equal(envelope1.Message, envelope2.Message);
             Assert.Equal(envelope1.CorrelationId, envelope2.CorrelationId);
 
+            if (_isFifo)
+                await _queue.CompleteAsync(envelope2);
+
             await _queue.CloseAsync(null);
         }
-
     }
 }

--- a/test/Queues/MessageQueueFixture.cs
+++ b/test/Queues/MessageQueueFixture.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Xunit;
 using PipServices3.Messaging.Queues;
+using PipServices3.Commons.Data;
 
 namespace PipServices3.Aws.Queues
 {
@@ -18,7 +19,7 @@ namespace PipServices3.Aws.Queues
 
         public async Task TestSendReceiveMessageAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
             await _queue.SendAsync(null, envelope1);
 
             var count = _queue.MessageCount;
@@ -29,11 +30,14 @@ namespace PipServices3.Aws.Queues
             Assert.Equal(envelope1.MessageType, envelope2.MessageType);
             Assert.Equal(envelope1.Message, envelope2.Message);
             Assert.Equal(envelope1.CorrelationId, envelope2.CorrelationId);
+
+            if (_isFifo)
+                await _queue.CompleteAsync(envelope2);
         }
 
         public async Task TestMoveToDeadMessageAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
             await _queue.SendAsync(null, envelope1);
 
             var envelope2 = await _queue.ReceiveAsync(null, 10000);
@@ -47,9 +51,10 @@ namespace PipServices3.Aws.Queues
 
         public async Task TestReceiveSendMessageAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
 
-            ThreadPool.QueueUserWorkItem(async delegate {
+            ThreadPool.QueueUserWorkItem(async delegate
+            {
                 Thread.Sleep(500);
                 await _queue.SendAsync(null, envelope1);
             });
@@ -59,11 +64,14 @@ namespace PipServices3.Aws.Queues
             Assert.Equal(envelope1.MessageType, envelope2.MessageType);
             Assert.Equal(envelope1.Message, envelope2.Message);
             Assert.Equal(envelope1.CorrelationId, envelope2.CorrelationId);
+
+            if (_isFifo)
+                await _queue.CompleteAsync(envelope2);
         }
 
         public async Task TestReceiveAndCompleteMessageAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
             await _queue.SendAsync(null, envelope1);
             var envelope2 = await _queue.ReceiveAsync(null, 10000);
             Assert.NotNull(envelope2);
@@ -78,7 +86,7 @@ namespace PipServices3.Aws.Queues
 
         public async Task TestReceiveAndAbandonMessageAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
             await _queue.SendAsync(null, envelope1);
             var envelope2 = await _queue.ReceiveAsync(null, 10000);
             Assert.NotNull(envelope2);
@@ -92,18 +100,28 @@ namespace PipServices3.Aws.Queues
             Assert.Equal(envelope1.MessageType, envelope2.MessageType);
             Assert.Equal(envelope1.Message, envelope2.Message);
             Assert.Equal(envelope1.CorrelationId, envelope2.CorrelationId);
+
+            if (_isFifo)
+                await _queue.CompleteAsync(envelope2);
         }
 
         public async Task TestSendPeekMessageAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
             await _queue.SendAsync(null, envelope1);
             await Task.Delay(500);
+
             var envelope2 = await _queue.PeekAsync(null);
             Assert.NotNull(envelope2);
             Assert.Equal(envelope1.MessageType, envelope2.MessageType);
             Assert.Equal(envelope1.Message, envelope2.Message);
             Assert.Equal(envelope1.CorrelationId, envelope2.CorrelationId);
+
+            if (_isFifo)
+            {
+                envelope2 = await _queue.ReceiveAsync(null, 10000);
+                await _queue.CompleteAsync(envelope2);
+            }
         }
 
         public async Task TestPeekNoMessageAsync()
@@ -114,20 +132,28 @@ namespace PipServices3.Aws.Queues
 
         public async Task TestMessageCountAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
             await _queue.SendAsync(null, envelope1);
             await Task.Delay(500);
+
             var count = _queue.MessageCount;
             Assert.NotNull(count);
             Assert.True(count.Value >= 1);
+
+            if (_isFifo)
+            {
+                var envelope2 = await _queue.ReceiveAsync(null, 10000);
+                await _queue.CompleteAsync(envelope2);
+            }
         }
 
         public async Task TestOnMessageAsync()
         {
-            var envelope1 = new MessageEnvelope("123", "Test", "Test message");
+            var envelope1 = new MessageEnvelope(IdGenerator.NextLong(), "Test", "Test message");
             MessageEnvelope envelope2 = null;
 
-            _queue.BeginListen(null, async (envelope, queue) => {
+            _queue.BeginListen(null, async (envelope, queue) =>
+            {
                 envelope2 = envelope;
                 await Task.Delay(0);
             });
@@ -140,8 +166,10 @@ namespace PipServices3.Aws.Queues
             Assert.Equal(envelope1.Message, envelope2.Message);
             Assert.Equal(envelope1.CorrelationId, envelope2.CorrelationId);
 
+            if (_isFifo)
+                await _queue.CompleteAsync(envelope2);
+
             await _queue.CloseAsync(null);
         }
-
     }
 }

--- a/test/Queues/SqsFifoMessageQueueTest.cs
+++ b/test/Queues/SqsFifoMessageQueueTest.cs
@@ -1,0 +1,35 @@
+﻿using PipServices3.Commons.Config;
+using System;
+
+namespace PipServices3.Aws.Queues
+{
+    public class SqsFifoMessageQueueTest : SqsMessageQueueTest
+    {
+        public SqsFifoMessageQueueTest() : base()
+        {
+        }
+
+        public override void Setup()
+        {
+            AWS_QUEUE_ARN = Environment.GetEnvironmentVariable("AWS_FIFO_QUEUE_ARN");
+            AWS_QUEUE = Environment.GetEnvironmentVariable("AWS_FIFO_QUEUE") ?? "TestQueue.fifo";
+            AWS_DEAD_QUEUE = Environment.GetEnvironmentVariable("AWS_DEAD_FIFO_QUEUE") ?? "TestQueueDLQ.fifo";
+
+            _queue = new SqsMessageQueue(AWS_QUEUE);
+
+            _queue.Configure(ConfigParams.FromTuples(
+                    "connection.uri", AWS_QUEUE_ARN,
+                    "connection.region", AWS_REGION,
+                    "connection.account", AWS_ACCOUNT,
+                    "credential.access_id", AWS_ACCESS_ID,
+                    "credential.access_key", AWS_ACCESS_KEY,
+                    "connection.queue", AWS_QUEUE,
+                    "connection.dead_queue", AWS_DEAD_QUEUE
+                ));
+
+            _queue.OpenAsync(null).Wait();
+
+            _fixture = new MessageQueueFixture(_queue, AWS_QUEUE.EndsWith(".fifo"));
+        }
+    }
+}

--- a/test/Queues/SqsMessageQueueTest.cs
+++ b/test/Queues/SqsMessageQueueTest.cs
@@ -5,39 +5,57 @@ using Xunit;
 
 namespace PipServices3.Aws.Queues
 {
-    public class SqsMessageQueueTest: IDisposable
+    public class SqsMessageQueueTest : IDisposable
     {
-        private bool _enabled;
-        private SqsMessageQueue _queue;
-        MessageQueueFixture _fixture;
+        protected bool _enabled;
+        protected SqsMessageQueue _queue;
+        protected MessageQueueFixture _fixture;
+
+        protected string AWS_ENABLED;
+        protected string AWS_REGION;
+        protected string AWS_ACCOUNT;
+        protected string AWS_ACCESS_ID;
+        protected string AWS_ACCESS_KEY;
+        protected string AWS_QUEUE_ARN;
+        protected string AWS_QUEUE;
+        protected string AWS_DEAD_QUEUE;
 
         public SqsMessageQueueTest()
         {
-            var AWS_ENABLED = Environment.GetEnvironmentVariable("AWS_ENABLED") ?? "true";
-            var AWS_REGION = Environment.GetEnvironmentVariable("AWS_REGION") ?? "us-east-1";
-            var AWS_ACCOUNT = Environment.GetEnvironmentVariable("AWS_ACCOUNT");
-            var AWS_ACCESS_ID = Environment.GetEnvironmentVariable("AWS_ACCESS_ID") ?? "AKIAI2B3PGHEAAK4BPUQ";
-            var AWS_ACCESS_KEY = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY") ?? "zQZGX0vGL6OD936fCcP1v6YmpiSdW28oUcezAnb7";
-            var AWS_QUEUE_ARN = Environment.GetEnvironmentVariable("AWS_QUEUE_ARN");
+            AWS_ENABLED = Environment.GetEnvironmentVariable("AWS_ENABLED") ?? "true";
+            AWS_REGION = Environment.GetEnvironmentVariable("AWS_REGION") ?? "us-east-1";
+            AWS_ACCOUNT = Environment.GetEnvironmentVariable("AWS_ACCOUNT");
+            AWS_ACCESS_ID = Environment.GetEnvironmentVariable("AWS_ACCESS_ID");
+            AWS_ACCESS_KEY = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY");
 
             _enabled = BooleanConverter.ToBoolean(AWS_ENABLED);
 
             if (_enabled)
-            {
-                _queue = new SqsMessageQueue("TestQueue");
-                _queue.Configure(ConfigParams.FromTuples(
+                Setup();
+        }
+
+        public virtual void Setup()
+        {
+            AWS_QUEUE_ARN = Environment.GetEnvironmentVariable("AWS_QUEUE_ARN");
+            AWS_QUEUE = Environment.GetEnvironmentVariable("AWS_QUEUE") ?? "TestQueue";
+            AWS_DEAD_QUEUE = Environment.GetEnvironmentVariable("AWS_DEAD_QUEUE") ?? "TestQueueDLQ";
+
+            _queue = new SqsMessageQueue(AWS_QUEUE);
+
+            _queue.Configure(ConfigParams.FromTuples(
                     "connection.uri", AWS_QUEUE_ARN,
                     "connection.region", AWS_REGION,
                     "connection.account", AWS_ACCOUNT,
                     "credential.access_id", AWS_ACCESS_ID,
-                    "credential.access_key", AWS_ACCESS_KEY
+                    "credential.access_key", AWS_ACCESS_KEY,
+                    "connection.queue", AWS_QUEUE,
+                    "connection.dead_queue", AWS_DEAD_QUEUE
                 ));
 
-                _queue.OpenAsync(null).Wait();
-                _queue.ClearAsync(null).Wait();
+            _queue.OpenAsync(null).Wait();
+            _queue.ClearAsync(null).Wait();
 
-                _fixture = new MessageQueueFixture(_queue);
-            }
+            _fixture = new MessageQueueFixture(_queue, AWS_QUEUE.EndsWith(".fifo"));
         }
 
         public void Dispose()

--- a/test/Queues/SqsMessageQueueTest.cs
+++ b/test/Queues/SqsMessageQueueTest.cs
@@ -7,18 +7,18 @@ namespace PipServices3.Aws.Queues
 {
     public class SqsMessageQueueTest : IDisposable
     {
-        private bool _enabled;
-        private SqsMessageQueue _queue;
-        MessageQueueFixture _fixture;
+        protected bool _enabled;
+        protected SqsMessageQueue _queue;
+        protected MessageQueueFixture _fixture;
 
-        private string AWS_ENABLED;
-        private string AWS_REGION;
-        private string AWS_ACCOUNT;
-        private string AWS_ACCESS_ID;
-        private string AWS_ACCESS_KEY;
-        private string AWS_QUEUE_ARN;
-        private string AWS_QUEUE;
-        private string AWS_DEAD_QUEUE;
+        protected string AWS_ENABLED;
+        protected string AWS_REGION;
+        protected string AWS_ACCOUNT;
+        protected string AWS_ACCESS_ID;
+        protected string AWS_ACCESS_KEY;
+        protected string AWS_QUEUE_ARN;
+        protected string AWS_QUEUE;
+        protected string AWS_DEAD_QUEUE;
 
         public SqsMessageQueueTest()
         {
@@ -29,6 +29,33 @@ namespace PipServices3.Aws.Queues
             AWS_ACCESS_KEY = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY");
 
             _enabled = BooleanConverter.ToBoolean(AWS_ENABLED);
+
+            if (_enabled)
+                Setup();
+        }
+
+        public virtual void Setup()
+        {
+            AWS_QUEUE_ARN = Environment.GetEnvironmentVariable("AWS_QUEUE_ARN");
+            AWS_QUEUE = Environment.GetEnvironmentVariable("AWS_QUEUE") ?? "TestQueue";
+            AWS_DEAD_QUEUE = Environment.GetEnvironmentVariable("AWS_DEAD_QUEUE") ?? "TestQueueDLQ";
+
+            _queue = new SqsMessageQueue(AWS_QUEUE);
+
+            _queue.Configure(ConfigParams.FromTuples(
+                    "connection.uri", AWS_QUEUE_ARN,
+                    "connection.region", AWS_REGION,
+                    "connection.account", AWS_ACCOUNT,
+                    "credential.access_id", AWS_ACCESS_ID,
+                    "credential.access_key", AWS_ACCESS_KEY,
+                    "connection.queue", AWS_QUEUE,
+                    "connection.dead_queue", AWS_DEAD_QUEUE
+                ));
+
+            _queue.OpenAsync(null).Wait();
+            _queue.ClearAsync(null).Wait();
+
+            _fixture = new MessageQueueFixture(_queue, AWS_QUEUE.EndsWith(".fifo"));
         }
 
         public void Dispose()
@@ -37,165 +64,67 @@ namespace PipServices3.Aws.Queues
                 _queue.CloseAsync(null).Wait();
         }
 
-        private void ConfigureStandardQueue()
-        {
-            AWS_QUEUE_ARN = Environment.GetEnvironmentVariable("AWS_QUEUE_ARN");
-            AWS_QUEUE = Environment.GetEnvironmentVariable("AWS_QUEUE") ?? "TestQueue";
-            AWS_DEAD_QUEUE = Environment.GetEnvironmentVariable("AWS_DEAD_QUEUE") ?? "TestQueueDLQ";
-
-            if (_enabled)
-            {
-                _queue = new SqsMessageQueue(AWS_QUEUE);
-                _queue.Configure(ConfigParams.FromTuples(
-                    "connection.uri", AWS_QUEUE_ARN,
-                    "connection.region", AWS_REGION,
-                    "connection.account", AWS_ACCOUNT,
-                    "credential.access_id", AWS_ACCESS_ID,
-                    "credential.access_key", AWS_ACCESS_KEY,
-                    "connection.queue", AWS_QUEUE,
-                    "connection.dead_queue", AWS_DEAD_QUEUE
-                ));
-
-                _queue.OpenAsync(null).Wait();
-                _queue.ClearAsync(null).Wait();
-
-                _fixture = new MessageQueueFixture(_queue, AWS_QUEUE.EndsWith(".fifo"));
-            }
-        }
-
-        private void ConfigureFifoTest()
-        {
-            AWS_QUEUE_ARN = Environment.GetEnvironmentVariable("AWS_FIFO_QUEUE_ARN");
-            AWS_QUEUE = Environment.GetEnvironmentVariable("AWS_FIFO_QUEUE") ?? "TestQueue.fifo";
-            AWS_DEAD_QUEUE = Environment.GetEnvironmentVariable("AWS_DEAD_FIFO_QUEUE") ?? "TestQueueDLQ.fifo";
-
-            if (_enabled)
-            {
-                _queue = new SqsMessageQueue(AWS_QUEUE);
-                _queue.Configure(ConfigParams.FromTuples(
-                    "connection.uri", AWS_QUEUE_ARN,
-                    "connection.region", AWS_REGION,
-                    "connection.account", AWS_ACCOUNT,
-                    "credential.access_id", AWS_ACCESS_ID,
-                    "credential.access_key", AWS_ACCESS_KEY,
-                    "connection.queue", AWS_QUEUE,
-                    "connection.dead_queue", AWS_DEAD_QUEUE
-                ));
-
-                _queue.OpenAsync(null).Wait();
-
-                _fixture = new MessageQueueFixture(_queue, AWS_QUEUE.EndsWith(".fifo"));
-            }
-        }
-
-        [Fact]
-        public void TestAmazonSqsFifoQueue()
-        {
-            if (_enabled)
-            {
-                ConfigureFifoTest();
-
-                _fixture.TestMoveToDeadMessageAsync().Wait();
-                _fixture.TestReceiveAndCompleteMessageAsync().Wait();
-                _fixture.TestPeekNoMessageAsync().Wait();
-
-                _fixture.TestSendReceiveMessageAsync().Wait();
-                _fixture.TestReceiveSendMessageAsync().Wait();
-                _fixture.TestReceiveAndAbandonMessageAsync().Wait();
-                _fixture.TestSendPeekMessageAsync().Wait();
-                _fixture.TestMessageCountAsync().Wait();
-                _fixture.TestOnMessageAsync().Wait();
-            }
-        }
-
         [Fact]
         public void TestAmazonSqsSendReceiveMessage()
         {
             if (_enabled)
-            {
-                ConfigureStandardQueue();
                 _fixture.TestSendReceiveMessageAsync().Wait();
-            }
         }
 
         [Fact]
         public void TestAmazonSqsReceiveSendMessage()
         {
             if (_enabled)
-            {
-                ConfigureStandardQueue();
                 _fixture.TestReceiveSendMessageAsync().Wait();
-            }
         }
 
         [Fact]
         public void TestAmazonSqsReceiveAndComplete()
         {
             if (_enabled)
-            {
-                ConfigureStandardQueue();
                 _fixture.TestReceiveAndCompleteMessageAsync().Wait();
-            }
         }
 
         [Fact]
         public void TestAmazonSqsReceiveAndAbandon()
         {
             if (_enabled)
-            {
-                ConfigureStandardQueue();
                 _fixture.TestReceiveAndAbandonMessageAsync().Wait();
-            }
         }
 
         [Fact]
         public void TestAmazonSqsSendPeekMessage()
         {
             if (_enabled)
-            {
-                ConfigureStandardQueue();
                 _fixture.TestSendPeekMessageAsync().Wait();
-            }
         }
 
         [Fact]
         public void TestAmazonSqsPeekNoMessage()
         {
             if (_enabled)
-            {
-                ConfigureStandardQueue();
                 _fixture.TestPeekNoMessageAsync().Wait();
-            }
         }
 
         [Fact]
         public void TestAmazonSqsOnMessage()
         {
             if (_enabled)
-            {
-                ConfigureStandardQueue();
                 _fixture.TestOnMessageAsync().Wait();
-            }
         }
 
         [Fact]
         public void TestAmazonSqsMoveToDeadMessage()
         {
             if (_enabled)
-            {
-                ConfigureStandardQueue();
                 _fixture.TestMoveToDeadMessageAsync().Wait();
-            }
         }
 
         [Fact]
         public void TestAmazonSqsMessageCount()
         {
             if (_enabled)
-            {
-                ConfigureStandardQueue();
                 _fixture.TestMessageCountAsync().Wait();
-            }
         }
     }
 }

--- a/test/Queues/SqsMessageQueueTest.cs
+++ b/test/Queues/SqsMessageQueueTest.cs
@@ -83,9 +83,28 @@ namespace PipServices3.Aws.Queues
                 ));
 
                 _queue.OpenAsync(null).Wait();
-                _queue.ClearAsync(null).Wait();
 
                 _fixture = new MessageQueueFixture(_queue, AWS_QUEUE.EndsWith(".fifo"));
+            }
+        }
+
+        [Fact]
+        public void TestAmazonSqsFifoQueue()
+        {
+            if (_enabled)
+            {
+                ConfigureFifoTest();
+
+                _fixture.TestMoveToDeadMessageAsync().Wait();
+                _fixture.TestReceiveAndCompleteMessageAsync().Wait();
+                _fixture.TestPeekNoMessageAsync().Wait();
+
+                _fixture.TestSendReceiveMessageAsync().Wait();
+                _fixture.TestReceiveSendMessageAsync().Wait();
+                _fixture.TestReceiveAndAbandonMessageAsync().Wait();
+                _fixture.TestSendPeekMessageAsync().Wait();
+                _fixture.TestMessageCountAsync().Wait();
+                _fixture.TestOnMessageAsync().Wait();
             }
         }
 

--- a/test/Queues/SqsMessageQueueTest.cs
+++ b/test/Queues/SqsMessageQueueTest.cs
@@ -5,39 +5,30 @@ using Xunit;
 
 namespace PipServices3.Aws.Queues
 {
-    public class SqsMessageQueueTest: IDisposable
+    public class SqsMessageQueueTest : IDisposable
     {
         private bool _enabled;
         private SqsMessageQueue _queue;
         MessageQueueFixture _fixture;
 
+        private string AWS_ENABLED;
+        private string AWS_REGION;
+        private string AWS_ACCOUNT;
+        private string AWS_ACCESS_ID;
+        private string AWS_ACCESS_KEY;
+        private string AWS_QUEUE_ARN;
+        private string AWS_QUEUE;
+        private string AWS_DEAD_QUEUE;
+
         public SqsMessageQueueTest()
         {
-            var AWS_ENABLED = Environment.GetEnvironmentVariable("AWS_ENABLED") ?? "true";
-            var AWS_REGION = Environment.GetEnvironmentVariable("AWS_REGION") ?? "us-east-1";
-            var AWS_ACCOUNT = Environment.GetEnvironmentVariable("AWS_ACCOUNT");
-            var AWS_ACCESS_ID = Environment.GetEnvironmentVariable("AWS_ACCESS_ID") ?? "AKIAI2B3PGHEAAK4BPUQ";
-            var AWS_ACCESS_KEY = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY") ?? "zQZGX0vGL6OD936fCcP1v6YmpiSdW28oUcezAnb7";
-            var AWS_QUEUE_ARN = Environment.GetEnvironmentVariable("AWS_QUEUE_ARN");
+            AWS_ENABLED = Environment.GetEnvironmentVariable("AWS_ENABLED") ?? "true";
+            AWS_REGION = Environment.GetEnvironmentVariable("AWS_REGION") ?? "us-east-1";
+            AWS_ACCOUNT = Environment.GetEnvironmentVariable("AWS_ACCOUNT");
+            AWS_ACCESS_ID = Environment.GetEnvironmentVariable("AWS_ACCESS_ID");
+            AWS_ACCESS_KEY = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY");
 
             _enabled = BooleanConverter.ToBoolean(AWS_ENABLED);
-
-            if (_enabled)
-            {
-                _queue = new SqsMessageQueue("TestQueue");
-                _queue.Configure(ConfigParams.FromTuples(
-                    "connection.uri", AWS_QUEUE_ARN,
-                    "connection.region", AWS_REGION,
-                    "connection.account", AWS_ACCOUNT,
-                    "credential.access_id", AWS_ACCESS_ID,
-                    "credential.access_key", AWS_ACCESS_KEY
-                ));
-
-                _queue.OpenAsync(null).Wait();
-                _queue.ClearAsync(null).Wait();
-
-                _fixture = new MessageQueueFixture(_queue);
-            }
         }
 
         public void Dispose()
@@ -46,67 +37,146 @@ namespace PipServices3.Aws.Queues
                 _queue.CloseAsync(null).Wait();
         }
 
+        private void ConfigureStandardQueue()
+        {
+            AWS_QUEUE_ARN = Environment.GetEnvironmentVariable("AWS_QUEUE_ARN");
+            AWS_QUEUE = Environment.GetEnvironmentVariable("AWS_QUEUE") ?? "TestQueue";
+            AWS_DEAD_QUEUE = Environment.GetEnvironmentVariable("AWS_DEAD_QUEUE") ?? "TestQueueDLQ";
+
+            if (_enabled)
+            {
+                _queue = new SqsMessageQueue(AWS_QUEUE);
+                _queue.Configure(ConfigParams.FromTuples(
+                    "connection.uri", AWS_QUEUE_ARN,
+                    "connection.region", AWS_REGION,
+                    "connection.account", AWS_ACCOUNT,
+                    "credential.access_id", AWS_ACCESS_ID,
+                    "credential.access_key", AWS_ACCESS_KEY,
+                    "connection.queue", AWS_QUEUE,
+                    "connection.dead_queue", AWS_DEAD_QUEUE
+                ));
+
+                _queue.OpenAsync(null).Wait();
+                _queue.ClearAsync(null).Wait();
+
+                _fixture = new MessageQueueFixture(_queue, AWS_QUEUE.EndsWith(".fifo"));
+            }
+        }
+
+        private void ConfigureFifoTest()
+        {
+            AWS_QUEUE_ARN = Environment.GetEnvironmentVariable("AWS_FIFO_QUEUE_ARN");
+            AWS_QUEUE = Environment.GetEnvironmentVariable("AWS_FIFO_QUEUE") ?? "TestQueue.fifo";
+            AWS_DEAD_QUEUE = Environment.GetEnvironmentVariable("AWS_DEAD_FIFO_QUEUE") ?? "TestQueueDLQ.fifo";
+
+            if (_enabled)
+            {
+                _queue = new SqsMessageQueue(AWS_QUEUE);
+                _queue.Configure(ConfigParams.FromTuples(
+                    "connection.uri", AWS_QUEUE_ARN,
+                    "connection.region", AWS_REGION,
+                    "connection.account", AWS_ACCOUNT,
+                    "credential.access_id", AWS_ACCESS_ID,
+                    "credential.access_key", AWS_ACCESS_KEY,
+                    "connection.queue", AWS_QUEUE,
+                    "connection.dead_queue", AWS_DEAD_QUEUE
+                ));
+
+                _queue.OpenAsync(null).Wait();
+                _queue.ClearAsync(null).Wait();
+
+                _fixture = new MessageQueueFixture(_queue, AWS_QUEUE.EndsWith(".fifo"));
+            }
+        }
+
         [Fact]
         public void TestAmazonSqsSendReceiveMessage()
         {
             if (_enabled)
+            {
+                ConfigureStandardQueue();
                 _fixture.TestSendReceiveMessageAsync().Wait();
+            }
         }
 
         [Fact]
         public void TestAmazonSqsReceiveSendMessage()
         {
             if (_enabled)
+            {
+                ConfigureStandardQueue();
                 _fixture.TestReceiveSendMessageAsync().Wait();
+            }
         }
 
         [Fact]
         public void TestAmazonSqsReceiveAndComplete()
         {
             if (_enabled)
+            {
+                ConfigureStandardQueue();
                 _fixture.TestReceiveAndCompleteMessageAsync().Wait();
+            }
         }
 
         [Fact]
         public void TestAmazonSqsReceiveAndAbandon()
         {
             if (_enabled)
+            {
+                ConfigureStandardQueue();
                 _fixture.TestReceiveAndAbandonMessageAsync().Wait();
+            }
         }
 
         [Fact]
         public void TestAmazonSqsSendPeekMessage()
         {
             if (_enabled)
+            {
+                ConfigureStandardQueue();
                 _fixture.TestSendPeekMessageAsync().Wait();
+            }
         }
 
         [Fact]
         public void TestAmazonSqsPeekNoMessage()
         {
             if (_enabled)
+            {
+                ConfigureStandardQueue();
                 _fixture.TestPeekNoMessageAsync().Wait();
+            }
         }
 
         [Fact]
         public void TestAmazonSqsOnMessage()
         {
             if (_enabled)
+            {
+                ConfigureStandardQueue();
                 _fixture.TestOnMessageAsync().Wait();
+            }
         }
 
         [Fact]
         public void TestAmazonSqsMoveToDeadMessage()
         {
             if (_enabled)
+            {
+                ConfigureStandardQueue();
                 _fixture.TestMoveToDeadMessageAsync().Wait();
+            }
         }
 
         [Fact]
         public void TestAmazonSqsMessageCount()
         {
             if (_enabled)
+            {
+                ConfigureStandardQueue();
                 _fixture.TestMessageCountAsync().Wait();
+            }
         }
     }
 }

--- a/test/Queues/SqsMessageQueueTest.cs
+++ b/test/Queues/SqsMessageQueueTest.cs
@@ -25,8 +25,8 @@ namespace PipServices3.Aws.Queues
             AWS_ENABLED = Environment.GetEnvironmentVariable("AWS_ENABLED") ?? "true";
             AWS_REGION = Environment.GetEnvironmentVariable("AWS_REGION") ?? "us-east-1";
             AWS_ACCOUNT = Environment.GetEnvironmentVariable("AWS_ACCOUNT");
-            AWS_ACCESS_ID = Environment.GetEnvironmentVariable("AWS_ACCESS_ID");
-            AWS_ACCESS_KEY = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY");
+            AWS_ACCESS_ID = Environment.GetEnvironmentVariable("AWS_ACCESS_ID") ?? "AKIAI2B3PGHEAAK4BPUQ";
+            AWS_ACCESS_KEY = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY") ?? "zQZGX0vGL6OD936fCcP1v6YmpiSdW28oUcezAnb7";
 
             _enabled = BooleanConverter.ToBoolean(AWS_ENABLED);
 


### PR DESCRIPTION
The SQSMessageQueue class has been updated to be able to use an AWS SQS FIFO Queue.
The class will automatically determine if the queue is FIFO by inspecting the queue name.

The MessageDeduplicationId will also be conditionally sent, the class will inspect the content deduplication policy for the queue and send the id accordingly.

Some typos and issues have also been addressed.